### PR TITLE
joeno-jquery-to-javascript-starter

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -37,7 +37,7 @@ body {
 .fighter-ready,
 .fighter-throwing,
 .fighter-cool,
-.hadouken {
+#hadouken {
   display: none;
 }
 
@@ -57,7 +57,7 @@ body {
   background-image: url('../images/ryu-cool.gif');
 }
 
-.hadouken,
+#hadouken,
 .fighter-ready,
 .fighter-still,
 .fighter-throwing,
@@ -65,15 +65,29 @@ body {
   background-repeat: no-repeat;
 }
 
-.hadouken {
+#hadouken {
   background-image: url('../images/hadouken.gif');
   width: 156px;
   height: 90px;
   position: absolute;
   z-index: 10;
   top: 280px;
-  left: 450px;
+  left: 550px;
   float: left;
+  animation: fireBall 500ms forwards 1;
+  -moz-animation: fireBall 500ms forwards 1;
+  -webkit-animation: fireBall 500ms forwards 1;
+  -webkit-animation-fill-mode: forwards;
+  animation-fill-mode: forwards;
+}
+
+@-webkit-keyframes fireBall {
+  from {left: 550px;}
+  to {left: 1020px;}
+}
+@keyframes fireBall {
+  from {left: 550px;}
+  to {left: 1020px;}
 }
 
 .instructions
@@ -95,3 +109,7 @@ body {
 
   align-self: flex-end;
 }
+
+/** {
+  outline: red 1px solid;
+}*/

--- a/css/main.css
+++ b/css/main.css
@@ -37,7 +37,7 @@ body {
 .fighter-ready,
 .fighter-throwing,
 .fighter-cool,
-#hadouken {
+.hadouken {
   display: none;
 }
 
@@ -57,7 +57,7 @@ body {
   background-image: url('../images/ryu-cool.gif');
 }
 
-#hadouken,
+.hadouken,
 .fighter-ready,
 .fighter-still,
 .fighter-throwing,
@@ -65,7 +65,7 @@ body {
   background-repeat: no-repeat;
 }
 
-#hadouken {
+.hadouken {
   background-image: url('../images/hadouken.gif');
   width: 156px;
   height: 90px;
@@ -74,20 +74,6 @@ body {
   top: 280px;
   left: 550px;
   float: left;
-  animation: fireBall 500ms forwards 1;
-  -moz-animation: fireBall 500ms forwards 1;
-  -webkit-animation: fireBall 500ms forwards 1;
-  -webkit-animation-fill-mode: forwards;
-  animation-fill-mode: forwards;
-}
-
-@-webkit-keyframes fireBall {
-  from {left: 550px;}
-  to {left: 1020px;}
-}
-@keyframes fireBall {
-  from {left: 550px;}
-  to {left: 1020px;}
 }
 
 .instructions

--- a/css/main.css
+++ b/css/main.css
@@ -26,42 +26,42 @@ body {
     height: 494px;
 }
 
-.ryu-ready,
-.ryu-still,
-.ryu-throwing,
-.ryu-cool {
+.fighter-ready,
+.fighter-still,
+.fighter-throwing,
+.fighter-cool {
   width: 659px;
   height: 494px;
 }
 
-.ryu-ready,
-.ryu-throwing,
-.ryu-cool,
+.fighter-ready,
+.fighter-throwing,
+.fighter-cool,
 .hadouken {
   display: none;
 }
 
-.ryu-ready {
+.fighter-ready {
   background-image: url('../images/ryu-ready-position.gif');
 }
 
-.ryu-still {
+.fighter-still {
   background-image: url('../images/ryu-standing-still.png');
 }
 
-.ryu-throwing {
+.fighter-throwing {
   background-image: url('../images/ryu-throwing-hadouken.png');
 }
 
-.ryu-cool {
+.fighter-cool {
   background-image: url('../images/ryu-cool.gif');
 }
 
 .hadouken,
-.ryu-ready,
-.ryu-still,
-.ryu-throwing,
-.ryu-cool {
+.fighter-ready,
+.fighter-still,
+.fighter-throwing,
+.fighter-cool {
   background-repeat: no-repeat;
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -1,79 +1,129 @@
 'use strict';
 /*jslint browser: true */
+var STATE = {
+	STILL: 'STILL',
+	COOL: 'COOL',
+	READY: 'READY',
+	THROW: 'THROW'
+};
+
+var LOCKED = {
+	YES: 'YES',
+	NO: 'NO',
+};
+
 // Our resource...
 function Fighter(fighterSelector) {
-  this.$hadouken = document.querySelector('#hadouken');
-  this.$fighter = document.querySelector(fighterSelector);
-  this.$fighterCool = this.$fighter.querySelector('.fighter-cool');
-  this.$fighterReady = this.$fighter.querySelector('.fighter-ready');
-  this.$fighterStill = this.$fighter.querySelector('.fighter-still');
-  this.$fighterThrowing = this.$fighter.querySelector('.fighter-throwing');
-  this.state = 'still';
+	this.$fighter = document.querySelector(fighterSelector);
+	this.$hadouken = this.$fighter.querySelector('.hadouken');
+	this.$fighterCool = this.$fighter.querySelector('.fighter-cool');
+	this.$fighterReady = this.$fighter.querySelector('.fighter-ready');
+	this.$fighterStill = this.$fighter.querySelector('.fighter-still');
+	this.$fighterThrowing = this.$fighter.querySelector('.fighter-throwing');
+	this.state = STATE.STILL;
 }
 
-// Its API
-Fighter.prototype.isReady = function() {
-  return this.state === 'ready';
-};
-Fighter.prototype.getReady = function() {
-  if (this.$fighterCool.classList.contains('down'))
-    ryu.beCool();
-  else if(this.$fighterThrowing.classList.contains('down'))
-    ryu.throwHadouken();
-  else if (!this.isReady()) {
-    this.state = 'ready';
-    hide(this.$fighterCool, this.$fighterStill, this.$fighterThrowing);
-    show(this.$fighterReady);
-  }
-};
-
 Fighter.prototype.isStill = function() {
-  return this.state === 'still';
+  return this.state === STATE.STILL;
 };
-Fighter.prototype.standStill = function() {
-  if (!this.isStill()) {
-    this.state = 'still';
-    hide(this.$fighterReady, this.$fighterCool, this.$fighterThrowing);
-    show(this.$fighterStill);
+Fighter.prototype.isReady = function() {
+  return this.state === STATE.READY;
+};
+Fighter.prototype.isCool = function() {
+  return this.state === STATE.COOL;
+};
+Fighter.prototype.isThrowing = function() {
+  return this.state === STATE.THROW;
+};
+
+Fighter.prototype.getStill = function() {
+	if(!this.isStill()) {
+    this.state = STATE.STILL;
+      hide(this.$fighterReady, this.$fighterThrowing, this.$fighterCool);
+      show(this.$fighterStill);
+  console.log(this.state);
   }
 };
 
-Fighter.prototype.beCool = function() {
-  this.$fighterCool.classList.add('down');
-  if ((this.state === 'ready')){
-    hide(this.$fighterReady);
-  }
-  else {
-    hide(this.$fighterStill);
-  }
-  show(this.$fighterCool);
-};
-Fighter.prototype.wasCool = function() {
-  this.$fighterCool.classList.remove('down');
-  hide(this.$fighterCool);
-  if (this.state === 'ready')
+Fighter.prototype.getReady = function() {
+	if(!this.isReady()) {
+    this.state = STATE.READY;
+	  hide(this.$fighterStill, this.$fighterThrowing, this.$fighterCool);
     show(this.$fighterReady);
-  else
-    show(this.$fighterStill);
+	}
+  console.log(this.state);
 };
 
-Fighter.prototype.throwHadouken = function() {
-  hide(this.$fighterReady, this.$fighterCool, this.$fighterStill);
-  show(this.$fighterThrowing);
+Fighter.prototype.getCool = function() {
+  if(!this.isCool()) {
+    this.oldState = this.state;
+    this.state = STATE.COOL;
+    hide(this.$fighterReady, this.$fighterThrowing, this.$fighterStill);
+    show(this.$fighterCool);
+  }
+  console.log(this.state);
 };
-Fighter.prototype.threwHadouken = function() {
-  hide(this.$fighterThrowing, this.$fighterCool, this.$fighterStill);
-  show(this.$fighterReady);
+
+Fighter.prototype.gotCool = function() {
+  if(this.oldState === 'READY'){
+    this.getReady();
+  } else {
+    this.getStill();
+  }
+  console.log(this.state);
 };
-Fighter.prototype.fireBall = function () {
-  show(this.$hadouken);
+
+Fighter.prototype.getFire = function() {
+  if(!this.isThrowing()) {
+    this.state = STATE.THROW;
+    this.useSuperpowers();
+  }
+  console.log(this.state);
+};
+
+Fighter.prototype.useSuperpowers = function() {
+  var fire = function(){
+		fireBall.style.left = currentPos + 'px';
+		currentPos += 30;
+		if(currentPos < 1020) {
+			fireBall.style.display = 'block';
+			requestAnimationFrame(fire);
+		} else {
+				fireBall.style.display = 'none';
+				fireBall.style.left = '500px';
+				currentPos = 500;
+		}
+		cancelAnimationFrame(fire);
+	};
+	// do {
+		hide(this.$fighterReady, this.$fighterStill, this.$fighterCool);
+		show(this.$fighterThrowing);
+	// } while(this.$hadouken.display.left < '1020px');
+
   fireHadouken();
+  fire();
 };
-Fighter.prototype.ballFired = function(){
-  hide(this.$hadouken);
-};
+
+// Some helpers...
+var currentPos = 500;
+function fireHadouken() {
+/*	$('#hadouken-sound')[0].volume = 0.2;
+	$('#hadouken-sound')[0].load();
+	$('#hadouken-sound')[0].play();*/
+}
+function hide() {
+  Array.prototype.forEach.call(arguments, function(el) {
+    el.style.display = 'none';
+  });
+}
+function show() {
+  Array.prototype.forEach.call(arguments, function(el) {
+    el.style.display = 'block';
+  });
+}
 // Our app
 var ryu = new Fighter('.ryu');
+var fireBall = ryu.$hadouken;
 var addEventListener = (function(){
   if(document.addEventListener)
     return function (element, event, handler) {
@@ -86,41 +136,19 @@ var addEventListener = (function(){
 }());
 
 addEventListener(ryu.$fighter, 'mouseenter', function() {
-  ryu.getReady();
+	ryu.getReady();
 });
 addEventListener(ryu.$fighter, 'mouseleave', function() {
-  ryu.standStill();
+	ryu.getStill();
 });
-
-addEventListener(ryu.$fighter, 'mouseup', function(){
-  ryu.throwHadouken();
-  ryu.fireBall();
-  setTimeout(function(){ryu.throwHadouken();}, 500);
-  setTimeout(function(){ryu.threwHadouken(); ryu.ballFired();}, 500);
+addEventListener(ryu.$fighter, 'click', function(){
+	ryu.getFire();
 });
-
 addEventListener(document, 'keydown', function(e) {
-  if (e.keyCode == 88)
-    ryu.beCool();
-  });
-addEventListener(document, 'keyup', function(e) {
-  if (e.keyCode == 88)
-  ryu.wasCool();
+	if (e.keyCode == 88)
+		ryu.getCool();
 });
-
-// Some helpers...
-function hide() {
-  Array.prototype.forEach.call(arguments, function(el) {
-    el.style.display = 'none';
-  });
-}
-function show() {
-  Array.prototype.forEach.call(arguments, function(el) {
-    el.style.display = 'block';
-  });
-}
-function fireHadouken () {
-  $('#hadouken-sound')[0].volume = 0.2;
-  $('#hadouken-sound')[0].load();
-  $('#hadouken-sound')[0].play();
-}
+addEventListener(document, 'keyup', function(e) {
+	if (e.keyCode == 88)
+		ryu.gotCool();
+});

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,8 @@
 'use strict';
-
+/*jslint browser: true */
 // Our resource...
 function Fighter(fighterSelector) {
-  this.$hadouken = document.querySelector('.hadouken');
+  this.$hadouken = document.querySelector('#hadouken');
   this.$fighter = document.querySelector(fighterSelector);
   this.$fighterCool = this.$fighter.querySelector('.fighter-cool');
   this.$fighterReady = this.$fighter.querySelector('.fighter-ready');
@@ -16,7 +16,11 @@ Fighter.prototype.isReady = function() {
   return this.state === 'ready';
 };
 Fighter.prototype.getReady = function() {
-  if (!this.isReady()) {
+	if (this.$fighterCool.classList.contains('down'))
+		ryu.beCool();
+	else if(this.$fighterThrowing.classList.contains('down'))
+		ryu.throwHadouken();
+  else if (!this.isReady()) {
     this.state = 'ready';
     hide(this.$fighterCool, this.$fighterStill, this.$fighterThrowing);
     show(this.$fighterReady);
@@ -29,39 +33,82 @@ Fighter.prototype.isStill = function() {
 Fighter.prototype.standStill = function() {
   if (!this.isStill()) {
     this.state = 'still';
-    hide(this.$fighterCool, this.$fighterReady, this.$fighterThrowing);
+    hide(this.$fighterReady, this.$fighterCool, this.$fighterThrowing);
     show(this.$fighterStill);
   }
 };
 
-Fighter.prototype.getGansta = function() {
-  // TODO ...
+Fighter.prototype.beCool = function() {
+    this.$fighterCool.classList.add('down');
+    if ((this.state === 'ready')){
+    hide(this.$fighterReady);
+  } else {
+    hide(this.$fighterStill);
+    }
+    show(this.$fighterCool);
+};
+Fighter.prototype.wasCool = function() {
+  this.$fighterCool.classList.remove('down');
+  hide(this.$fighterCool);
+  if (this.state === 'ready')
+    show(this.$fighterReady);
+  else
+  	show(this.$fighterStill);
 };
 
 Fighter.prototype.throwHadouken = function() {
-  // TODO ...
+	hide(this.$fighterReady, this.$fighterCool, this.$fighterStill);
+	show(this.$fighterThrowing);
 };
-
+Fighter.prototype.threwHadouken = function() {
+  hide(this.$fighterThrowing);
+  show(this.$fighterReady);
+};
+Fighter.prototype.fireBall = function () {
+	show(this.$hadouken);
+	fireHadouken();
+};
+Fighter.prototype.ballFired = function(){
+ 	hide(this.$hadouken);
+ };
 // Our app
 var ryu = new Fighter('.ryu');
-
-ryu.$fighter.addEventListener('mouseenter', function() {
-  ryu.getReady();
+var addEventListener = (function(){
+	if(document.addEventListener)
+		return function (element, event, handler) {
+			element.addEventListener(event, handler, false);
+		};
+	else
+		return function (element, event, handler) {
+			element.attachEvemt('on' + event, handler);
+		};
+}());
+addEventListener(ryu.$fighter, 'mouseenter', function() {  ryu.getReady();
 });
-ryu.$fighter.addEventListener('mouseleave', function() {
+addEventListener(ryu.$fighter, 'mouseleave', function() {
   ryu.standStill();
 });
 
-ryu.$fighter.addEventListener('', function(){
+addEventListener(ryu.$fighter, 'mouseup', function(){
+	ryu.throwHadouken();
+	ryu.fireBall();
 
+	setTimeout(function(){
+		ryu.throwHadouken();
+		}, 500);
+	setTimeout(function(){
+		ryu.threwHadouken();
+		ryu.ballFired();}, 500);
 });
-ryu.$fighter.addEventListener('', function(){
 
+
+addEventListener(document, 'keydown', function(e) {
+  if (e.keyCode == 88)ryu.beCool();
 });
-ryu.$fighter.addEventListener('', function(){
-
+addEventListener(document, 'keyup', function(e) {
+  if (e.keyCode == 88)
+    ryu.wasCool();
 });
-
 
 // Some helpers...
 function hide() {
@@ -74,42 +121,8 @@ function show() {
     el.style.display = 'block';
   });
 }
-
-// $(document).ready(function() {
-//   $('.ryu')
-//   .mousedown(function() {
-//     playHadouken();
-//     $('.ryu-ready, .ryu-cool, .ryu-still').hide();
-//     $('.ryu-throwing').show();
-//     $('.hadouken').finish().show()
-//     .animate(
-//       {'left': '1020px'},
-//       500,
-//       function() {
-//         $(this).hide();
-//         $(this).css('left', '450px');
-//       }
-//     );
-//   })
-//   .mouseup(function() {
-//     $('.ryu-throwing, .ryu-cool, .ryu-still').hide();
-//     $('.ryu-ready').show();
-//   });
-
-//   $(document).keydown(function(event){
-//     if(event.keyCode == 88){
-//       $('.ryu-still, .ryu-ready, .ryu-throwing').hide();
-//       $('.ryu-cool').show();
-//     }
-//   }).keyup(function(event){
-//       if (event.keyCode == 88);
-//         $('.ryu-cool, .ryu-ready, .ryu-throwing').hide();
-//         $('.ryu-still').show();
-//     });
-// });
-
-function playHadouken () {
-  $('#hadouken-sound')[0].volume = 0.5;
+function fireHadouken () {
+  $('#hadouken-sound')[0].volume = 0.2;
   $('#hadouken-sound')[0].load();
   $('#hadouken-sound')[0].play();
 }

--- a/js/app.js
+++ b/js/app.js
@@ -1,50 +1,60 @@
 'use strict';
 
 // Our resource...
-function Ryu(ryuSelector) {
+function Fighter(ryuSelector) {
   this.$hadouken = document.querySelector('.hadouken');
   this.$ryu = document.querySelector(ryuSelector);
   this.$ryuCool = this.$ryu.querySelector('.ryu-cool');
   this.$ryuReady = this.$ryu.querySelector('.ryu-ready');
   this.$ryuStill = this.$ryu.querySelector('.ryu-still');
   this.$ryuThrowing = this.$ryu.querySelector('.ryu-throwing');
-
   this.state = 'still';
 }
 
 // Its API
-Ryu.prototype.isReady = function() {
+Fighter.prototype.isReady = function() {
   return this.state === 'ready';
-}
-Ryu.prototype.getReady = function() {
+};
+Fighter.prototype.getReady = function() {
   if (!this.isReady()) {
     this.state = 'ready';
     hide(this.$ryuCool, this.$ryuStill, this.$ryuThrowing);
     show(this.$ryuReady);
   }
-}
+};
 
-Ryu.prototype.isStill = function() {
+Fighter.prototype.isStill = function() {
   return this.state === 'still';
-}
-Ryu.prototype.standStill = function() {
+};
+Fighter.prototype.standStill = function() {
   if (!this.isStill()) {
     this.state = 'still';
     hide(this.$ryuCool, this.$ryuReady, this.$ryuThrowing);
     show(this.$ryuStill);
   }
-}
+};
 
-Ryu.prototype.getGansta = function() {
-  // TODO ...
-}
+Fighter.prototype.getGansta = function() {
 
-Ryu.prototype.throwHadouken = function() {
-  // TODO ...
-}
+    hide(this.$ryuStill, this.$ryuReady, this.ryuThrowing);
+    show(this.$ryuCool);
+};
+
+
+
+Fighter.prototype.throwHadouken = function() {
+    // TODO ...
+    // change to throwing image
+    hide(this.$ryuStill, this.$ryuReady, this.$ryuCool);
+    show(this.ryuThrowing);
+    //animate hadouken and play Hadouken sound
+
+    //return to standstill
+
+};
 
 // Our app
-var ryu = new Ryu('.ryu');
+var ryu = new Fighter('.ryu');
 
 ryu.$ryu.addEventListener('mouseenter', function() {
   ryu.getReady();
@@ -52,6 +62,17 @@ ryu.$ryu.addEventListener('mouseenter', function() {
 ryu.$ryu.addEventListener('mouseleave', function() {
   ryu.standStill();
 });
+
+ryu.$ryu.addEventListener('', function(){
+
+});
+ryu.$ryu.addEventListener('', function(){
+
+});
+ryu.$ryu.addEventListener('', function(){
+
+});
+
 
 // Some helpers...
 function hide() {
@@ -65,38 +86,38 @@ function show() {
   });
 }
 
-$(document).ready(function() {
-  $('.ryu')
-  .mousedown(function() {
-    playHadouken();
-    $('.ryu-ready, .ryu-cool, .ryu-still').hide();
-    $('.ryu-throwing').show();
-    $('.hadouken').finish().show()
-    .animate(
-      {'left': '1020px'},
-      500,
-      function() {
-        $(this).hide();
-        $(this).css('left', '450px');
-      }
-    );
-  })
-  .mouseup(function() {
-    $('.ryu-throwing, .ryu-cool, .ryu-still').hide();
-    $('.ryu-ready').show();
-  });
+// $(document).ready(function() {
+//   $('.ryu')
+//   .mousedown(function() {
+//     playHadouken();
+//     $('.ryu-ready, .ryu-cool, .ryu-still').hide();
+//     $('.ryu-throwing').show();
+//     $('.hadouken').finish().show()
+//     .animate(
+//       {'left': '1020px'},
+//       500,
+//       function() {
+//         $(this).hide();
+//         $(this).css('left', '450px');
+//       }
+//     );
+//   })
+//   .mouseup(function() {
+//     $('.ryu-throwing, .ryu-cool, .ryu-still').hide();
+//     $('.ryu-ready').show();
+//   });
 
-  $(document).keydown(function(event){
-    if(event.keyCode == 88){
-      $('.ryu-still, .ryu-ready, .ryu-throwing').hide();
-      $('.ryu-cool').show();
-    }
-  }).keyup(function(event){
-      if (event.keyCode == 88);
-        $('.ryu-cool, .ryu-ready, .ryu-throwing').hide();
-        $('.ryu-still').show();
-    });
-});
+//   $(document).keydown(function(event){
+//     if(event.keyCode == 88){
+//       $('.ryu-still, .ryu-ready, .ryu-throwing').hide();
+//       $('.ryu-cool').show();
+//     }
+//   }).keyup(function(event){
+//       if (event.keyCode == 88);
+//         $('.ryu-cool, .ryu-ready, .ryu-throwing').hide();
+//         $('.ryu-still').show();
+//     });
+// });
 
 function playHadouken () {
   $('#hadouken-sound')[0].volume = 0.5;

--- a/js/app.js
+++ b/js/app.js
@@ -1,13 +1,13 @@
 'use strict';
 
 // Our resource...
-function Fighter(ryuSelector) {
+function Fighter(fighterSelector) {
   this.$hadouken = document.querySelector('.hadouken');
-  this.$ryu = document.querySelector(ryuSelector);
-  this.$ryuCool = this.$ryu.querySelector('.ryu-cool');
-  this.$ryuReady = this.$ryu.querySelector('.ryu-ready');
-  this.$ryuStill = this.$ryu.querySelector('.ryu-still');
-  this.$ryuThrowing = this.$ryu.querySelector('.ryu-throwing');
+  this.$fighter = document.querySelector(fighterSelector);
+  this.$fighterCool = this.$fighter.querySelector('.fighter-cool');
+  this.$fighterReady = this.$fighter.querySelector('.fighter-ready');
+  this.$fighterStill = this.$fighter.querySelector('.fighter-still');
+  this.$fighterThrowing = this.$fighter.querySelector('.fighter-throwing');
   this.state = 'still';
 }
 
@@ -18,8 +18,8 @@ Fighter.prototype.isReady = function() {
 Fighter.prototype.getReady = function() {
   if (!this.isReady()) {
     this.state = 'ready';
-    hide(this.$ryuCool, this.$ryuStill, this.$ryuThrowing);
-    show(this.$ryuReady);
+    hide(this.$fighterCool, this.$fighterStill, this.$fighterThrowing);
+    show(this.$fighterReady);
   }
 };
 
@@ -29,47 +29,36 @@ Fighter.prototype.isStill = function() {
 Fighter.prototype.standStill = function() {
   if (!this.isStill()) {
     this.state = 'still';
-    hide(this.$ryuCool, this.$ryuReady, this.$ryuThrowing);
-    show(this.$ryuStill);
+    hide(this.$fighterCool, this.$fighterReady, this.$fighterThrowing);
+    show(this.$fighterStill);
   }
 };
 
 Fighter.prototype.getGansta = function() {
-
-    hide(this.$ryuStill, this.$ryuReady, this.ryuThrowing);
-    show(this.$ryuCool);
+  // TODO ...
 };
 
-
-
 Fighter.prototype.throwHadouken = function() {
-    // TODO ...
-    // change to throwing image
-    hide(this.$ryuStill, this.$ryuReady, this.$ryuCool);
-    show(this.ryuThrowing);
-    //animate hadouken and play Hadouken sound
-
-    //return to standstill
-
+  // TODO ...
 };
 
 // Our app
 var ryu = new Fighter('.ryu');
 
-ryu.$ryu.addEventListener('mouseenter', function() {
+ryu.$fighter.addEventListener('mouseenter', function() {
   ryu.getReady();
 });
-ryu.$ryu.addEventListener('mouseleave', function() {
+ryu.$fighter.addEventListener('mouseleave', function() {
   ryu.standStill();
 });
 
-ryu.$ryu.addEventListener('', function(){
+ryu.$fighter.addEventListener('', function(){
 
 });
-ryu.$ryu.addEventListener('', function(){
+ryu.$fighter.addEventListener('', function(){
 
 });
-ryu.$ryu.addEventListener('', function(){
+ryu.$fighter.addEventListener('', function(){
 
 });
 

--- a/js/app.js
+++ b/js/app.js
@@ -16,10 +16,10 @@ Fighter.prototype.isReady = function() {
   return this.state === 'ready';
 };
 Fighter.prototype.getReady = function() {
-	if (this.$fighterCool.classList.contains('down'))
-		ryu.beCool();
-	else if(this.$fighterThrowing.classList.contains('down'))
-		ryu.throwHadouken();
+  if (this.$fighterCool.classList.contains('down'))
+    ryu.beCool();
+  else if(this.$fighterThrowing.classList.contains('down'))
+    ryu.throwHadouken();
   else if (!this.isReady()) {
     this.state = 'ready';
     hide(this.$fighterCool, this.$fighterStill, this.$fighterThrowing);
@@ -39,13 +39,14 @@ Fighter.prototype.standStill = function() {
 };
 
 Fighter.prototype.beCool = function() {
-    this.$fighterCool.classList.add('down');
-    if ((this.state === 'ready')){
+  this.$fighterCool.classList.add('down');
+  if ((this.state === 'ready')){
     hide(this.$fighterReady);
-  } else {
+  }
+  else {
     hide(this.$fighterStill);
-    }
-    show(this.$fighterCool);
+  }
+  show(this.$fighterCool);
 };
 Fighter.prototype.wasCool = function() {
   this.$fighterCool.classList.remove('down');
@@ -53,61 +54,58 @@ Fighter.prototype.wasCool = function() {
   if (this.state === 'ready')
     show(this.$fighterReady);
   else
-  	show(this.$fighterStill);
+    show(this.$fighterStill);
 };
 
 Fighter.prototype.throwHadouken = function() {
-	hide(this.$fighterReady, this.$fighterCool, this.$fighterStill);
-	show(this.$fighterThrowing);
+  hide(this.$fighterReady, this.$fighterCool, this.$fighterStill);
+  show(this.$fighterThrowing);
 };
 Fighter.prototype.threwHadouken = function() {
-  hide(this.$fighterThrowing);
+  hide(this.$fighterThrowing, this.$fighterCool, this.$fighterStill);
   show(this.$fighterReady);
 };
 Fighter.prototype.fireBall = function () {
-	show(this.$hadouken);
-	fireHadouken();
+  show(this.$hadouken);
+  fireHadouken();
 };
 Fighter.prototype.ballFired = function(){
- 	hide(this.$hadouken);
- };
+  hide(this.$hadouken);
+};
 // Our app
 var ryu = new Fighter('.ryu');
 var addEventListener = (function(){
-	if(document.addEventListener)
-		return function (element, event, handler) {
-			element.addEventListener(event, handler, false);
-		};
-	else
-		return function (element, event, handler) {
-			element.attachEvemt('on' + event, handler);
-		};
+  if(document.addEventListener)
+    return function (element, event, handler) {
+      element.addEventListener(event, handler, false);
+    };
+  else
+    return function (element, event, handler) {
+    element.attachEvemt('on' + event, handler);
+  };
 }());
-addEventListener(ryu.$fighter, 'mouseenter', function() {  ryu.getReady();
+
+addEventListener(ryu.$fighter, 'mouseenter', function() {
+  ryu.getReady();
 });
 addEventListener(ryu.$fighter, 'mouseleave', function() {
   ryu.standStill();
 });
 
 addEventListener(ryu.$fighter, 'mouseup', function(){
-	ryu.throwHadouken();
-	ryu.fireBall();
-
-	setTimeout(function(){
-		ryu.throwHadouken();
-		}, 500);
-	setTimeout(function(){
-		ryu.threwHadouken();
-		ryu.ballFired();}, 500);
+  ryu.throwHadouken();
+  ryu.fireBall();
+  setTimeout(function(){ryu.throwHadouken();}, 500);
+  setTimeout(function(){ryu.threwHadouken(); ryu.ballFired();}, 500);
 });
-
 
 addEventListener(document, 'keydown', function(e) {
-  if (e.keyCode == 88)ryu.beCool();
-});
+  if (e.keyCode == 88)
+    ryu.beCool();
+  });
 addEventListener(document, 'keyup', function(e) {
   if (e.keyCode == 88)
-    ryu.wasCool();
+  ryu.wasCool();
 });
 
 // Some helpers...

--- a/main.html
+++ b/main.html
@@ -11,12 +11,12 @@
   <body>
     <div class="main">
       <div class="ryu">
-          <div class="ryu-still"></div>
-          <div class="ryu-ready"></div>
-          <div class="ryu-throwing"></div>
-          <div class="ryu-cool"></div>
+          <div class="fighter-still"></div> // ?ade the fighter's resources more generic
+          <div class="fighter-ready"></div>
+          <div class="fighter-throwing"></div>
+          <div class="fighter-cool"></div>
+          <div class="hadouken"></div> // Moved the hadouken resource within the ryu frame so that only an object with class 'ryu' can use it?
       </div>
-      <div class="hadouken"></div>
       <div class="instructions">
         <p class="click-on">Click on <span class="keyword">Ryu</span> to make him throw a Hadouken.</p>
         <p class="press-on">Press and hold the <span class="keyword">"X"</span> for Ryu to get gangsta!</p>

--- a/main.html
+++ b/main.html
@@ -15,8 +15,9 @@
           <div class="fighter-ready"></div>
           <div class="fighter-throwing"></div>
           <div class="fighter-cool"></div>
-          <div class="hadouken"></div> <!-- Moved the hadouken resource within the ryu frame so that only an object with class 'ryu' can use it? -->
+          <div id="hadouken"></div>
       </div>
+
       <div class="instructions">
         <p class="click-on">Click on <span class="keyword">Ryu</span> to make him throw a Hadouken.</p>
         <p class="press-on">Press and hold the <span class="keyword">"X"</span> for Ryu to get gangsta!</p>

--- a/main.html
+++ b/main.html
@@ -15,7 +15,7 @@
           <div class="fighter-ready"></div>
           <div class="fighter-throwing"></div>
           <div class="fighter-cool"></div>
-          <div id="hadouken"></div>
+          <div class="hadouken"></div>
       </div>
 
       <div class="instructions">

--- a/main.html
+++ b/main.html
@@ -11,11 +11,11 @@
   <body>
     <div class="main">
       <div class="ryu">
-          <div class="fighter-still"></div> // ?ade the fighter's resources more generic
+          <div class="fighter-still"></div> <!-- Made the fighter's resources more generic -->
           <div class="fighter-ready"></div>
           <div class="fighter-throwing"></div>
           <div class="fighter-cool"></div>
-          <div class="hadouken"></div> // Moved the hadouken resource within the ryu frame so that only an object with class 'ryu' can use it?
+          <div class="hadouken"></div> <!-- Moved the hadouken resource within the ryu frame so that only an object with class 'ryu' can use it? -->
       </div>
       <div class="instructions">
         <p class="click-on">Click on <span class="keyword">Ryu</span> to make him throw a Hadouken.</p>


### PR DESCRIPTION
@dariocravero 

Ok... first things first before I pull my hair out and let me see if I have any idea what you're talking about. 

Part of my issue is that I need to see the bigger picture before I'm able to break things down into it's components. I'm not sure I understand the big picture yet...

**1. "First iteration towards no jQuery and resource modeling."**
I understand everything in this statement except for "resource modeling". Can you say that in plainer English? "Resource Modeling" sounds like "the process of making functions functional" or "build functional resources"

**2. Can you separate the character's API and its use? Why would this make sense?**
If **API** is the **Application Programming Interface**. In my head, APIs are essentially **actions** to be performed on a specific type of application. The actions say, **"DO SOMETHING"** to the application it's allowed to working with(in this case, Fighter).

To answer the "why" of it, if we're looking strictly at Street Fighter as an example, it's is so that we can potentially use the API on different Fighters, not just Ryu.

I cloned your PR branch and renamed mine, **pr-answer-branch**. In that, I changed the **'Ryu'** resource and API, to **'Fighter'** in order to make it and the API more generic. 

My reasoning is, if I then wanted to create run the app on a fighter class called '.ken', I wouldn't want to make:
`var ken = new Ryu('.ken')`

I'd want: 
`var ryu = new Fighter('.ryu');`
`var ken = new Fighter('.ken'); // then var var guile, var dhalsim etc etc etc....`

They'd all contain the Fighter resources and have access to the FighterAPI's actions. 

**Was this the correct thing to do? This is assuming that all Street Fighter characters can do all of those things. We know that only Ken and Ryu throw "hadoukens", If we were doing this fully, it'd make more sense to change 'this.$hadouken' to something like, 'this.$thrownObject'**

So in the app section I also changed $ryu to $fighter for the same reason. $fighter is equal to '.ryu' in this project so:
1. `var ryu = new Fighter('.ryu');` 
2. `ryu.$fighter.addEventListener('mouseenter', function() {
  ryu.getReady();
});`
1. Make a new Fighter named 'ryu'. He is anyone with a class '.ryu'.
2. Keep an eye on ryu('.ryu'). Whenever the mouse enters an area that's class .ryu, make ryu 'getReady()'. getReady() means, check to see if  his state is 'ready',  if it's not, then make it so, and hide everything that doesn't express a ready state and show him visually being ready. 

The standStill() portion of the app essentially backs out of the getReady() portion using mouseleave and return to a still state. 

**What I (think I) need to do**
API section:
1. `Fighter.prototype.getGangsta() // (1)hide(this.state, this.$fighterReady, Still, Throwing, and .hadouken), (2) show(this.$fighterCool)`
2. After thinking about it, I feel like a need a gotGangsta prototype, which returns show(this.state)....
3. `Fighter.prototype.throwHadouken() //  I think I want to (1) hide(this.state) along with all of the $fighter methods, (2) show($fighterThrowing), (3) show(.Hadouken), (4) animate(.Hadouken,) (5) hide(.Hadouken), (6) hide(fighterThrowing), (7) show(this.state)`
4. I think I need a threwHadouken to interact with the mouseup as well for the same reason as #2??

App section:
1. `ryu.$fighter.addEventListener('keydown', function(event){ if event.keyCode == 88, ryu.getGangsta });`
2. `ryu.$fighter.addEventListener('keyup', function(){ ryu.gotGangsta });`
3. `ryu.$fighter.addEventListener('mousedown', function(){ ryu.throwHadouken });`
4. `ryu.$fighter.addEventListener('mouseup', function(){ ryu.threwHadouken });`

**So that's how my brain is trying to work this problem out. Am I thinking properly?**
